### PR TITLE
Handle NA values in Z score when computing AUCs

### DIFF
--- a/R/processing_outputs.R
+++ b/R/processing_outputs.R
@@ -235,8 +235,8 @@ calculateAUC <- function(datList, sharedPairs = TRUE) {
         dplyr::filter(reference == pairs$reference[i]) %>%
         dplyr::filter(neighbor == pairs$neighbor[i]) %>%
         dplyr::group_by(neighbor, scale, reference) %>%
-        dplyr::summarise(mean = mean(Z),
-                         sd = sd(Z))
+        dplyr::summarise(mean = mean(Z, na.rm = TRUE),
+                         sd = sd(Z, na.rm = TRUE))
       
       ## calculate auc
       return(data.frame(id = sample_id,


### PR DESCRIPTION
Z score can be NAs for a ref-neighbor pair and a certain permutation, both true number of cells and the shuffled number of cells for neighbor type equals to 0. This commit allows output meaningful auc values even if Z scores for selected permutation are NA.